### PR TITLE
fix bug UnCaught TypeError: img.toPng is not a function

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -54,7 +54,7 @@ module.exports =
         uploaderIns = uploader.instance()
 
         uploadFn = (callback)->
-          uploaderIns.upload(img.toPng(), 'png', callback)
+          uploaderIns.upload(img.toPNG(), 'png', callback)
 
         insertImageViewInstance = new insertImageViewModule()
         insertImageViewInstance.display(uploadFn)


### PR DESCRIPTION
UnCaught TypeError: img.toPng is not a function 报错导致图片上传失败，
nativeImage中修改main.coffee第57行代码api名称改变
